### PR TITLE
Added some base functionality polish.

### DIFF
--- a/src/EcessClient.py
+++ b/src/EcessClient.py
@@ -6,35 +6,62 @@ import discord
 import os
 from discord.ext import commands
 
+
 def main():
-    # Enable privileged intents 
+    # Enable privileged intents
     # Certain methods (eg. `guild.get_members`) require privileged intents
     intents = discord.Intents.default()
     intents.members = True
 
     # Initialize the client
-    client = commands.Bot(intents=intents, command_prefix='!')
+    client = commands.Bot(intents=intents, command_prefix="!")
 
-    """
-    Load the cog extension
-    :param extension: extension to be loaded
-    """
+    @client.event
+    async def on_command_error(ctx, error):
+        if isinstance(error, commands.errors.CommandNotFound):
+            pass
+        elif isinstance(error, commands.errors.CommandOnCooldown):
+            await ctx.send("This command is on cooldown.")
+        elif isinstance(error, commands.errors.CheckFailure):
+            await ctx.send("You don't have permissions to use this command.")
+        elif isinstance(error, commands.errors.MaxConcurrencyReached):
+            await ctx.send(
+                "This command has reached the max number of concurrent jobs."
+            )
+        elif isinstance(error, commands.errors.MissingRequiredArgument) or isinstance(
+            error, commands.errors.BadArgument
+        ):
+            # A fresh instance of HelpCommand is required since
+            # we must manually pass the context here
+            help = commands.help.DefaultHelpCommand()
+            help.context = ctx
+            await ctx.send("Malformed arguments. Command help:")
+            await help.send_command_help(ctx.command)
+        else:
+            await ctx.send(f"An error occured with the {ctx.command.name} command.")
+
     @client.command()
+    @commands.is_owner()
     async def load(ctx, extension):
-        client.load_extension(f'cogs.{extension}')
+        """
+        Load the cog extension
+        :param extension: extension to be loaded
+        """
+        client.load_extension(f"cogs.{extension}")
 
-    """
-    Unload the cog extension
-    :param extension: extension to be unloaded
-    """
     @client.command()
+    @commands.is_owner()
     async def unload(ctx, extension):
-        client.unload_extension(f'cogs.{extension}')
+        """
+        Unload the cog extension
+        :param extension: extension to be unloaded
+        """
+        client.unload_extension(f"cogs.{extension}")
 
     # Load extensions inside of `cogs` directory
-    for filename in os.listdir('./cogs'):
-        if filename.endswith('.py'):
-            client.load_extension(f'cogs.{filename[:-3]}')
+    for filename in os.listdir("./cogs"):
+        if filename.endswith(".py"):
+            client.load_extension(f"cogs.{filename[:-3]}")
 
     # Read the bot token within `secrets`
     token_file = open("secrets/token.txt")
@@ -42,6 +69,7 @@ def main():
 
     # Run the client
     client.run(token)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This diff contains 3 main changes:
- Command error handling so users will know why a command failed
- Owner check for the cog load/unload commands
- Moved the docstrings for `load` and `unload` inline so that the function registers `__doc__` for the help formatting

Also ran black linting on the main file, so the diff might include some changes that aren't necessarily related. 