### PR TITLE
Role assignment improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,25 @@ The bot is currently not live. The instructions are meant for testing on your lo
 
 ## Features
 ### Role Distribution
-The roles are currently mapped to the following emotes.
-These can be remapped within the `RoleDistributor.py` file. 
-- :red_car: -> 2nd Year
-- :blue_car: -> 3rd Year
-- :racing_car: -> 4th Year
 
-Roles will be assigned upon adding a reaction. Roles will be unassigned upon removing a reaction. Reactions consisting of emojis not included above will do nothing. You can only have one role at a time.
+Roles can be distributed arbitrarily and set up with the interactive mapper within the `RoleDistributor.py` file.
+
+To set up a new role distributor, initialize a new session with `!initialize_role_mapping <message_id> [options]`. To get the message ID, hold shift and click on the `ID` icon to the right of the message (make sure you have Developer Mode enabled). Currently, the only option supported is `unique`, which is a flag for this listener that the roles being assigned are unique (ie. only one role from that listener can be assigned to single user at a time).
+
+With the session started, add new mappings with `!add_role_mapping <emote> <role_id>`. Note that you can also mention the role in order to set up the mapping. Both custom and unicode emotes are supported.
+
+Once you're done, finalize the mapping with `!finalize_role_mapping`. This will clear all the reactions on the targeted message, and initialize the mapped reactions.
+
+#### Caveats
+
+- The channel with the role reacts must grant everyone the `Add Reactions` permission. The bot will handle removing reactions that aren't mapped.
+
+- If you delete a mapped message, remember to delete the mapping too (`!delete_role_mapping <message_id>`). There won't be an error, but you won't be able to map those roles again until you've removed the old listeners.
+
+- Roles are unique; you cannot map the same role to multiple listeners or emotes.
+
+- Mapping can only be done by the bot owner at this time (TODO)
+
 
 ### Commands
 #### Prerequisite Checking

--- a/src/EcessClient.py
+++ b/src/EcessClient.py
@@ -17,6 +17,14 @@ def main():
     client = commands.Bot(intents=intents, command_prefix="!")
 
     @client.event
+    async def on_ready():
+        """
+        Print a message indicating it is ready
+        Primarily for debugging purposes
+        """
+        print("Bot is ready!")
+
+    @client.event
     async def on_command_error(ctx, error):
         if isinstance(error, commands.errors.CommandNotFound):
             pass

--- a/src/cogs/RoleDistributor.py
+++ b/src/cogs/RoleDistributor.py
@@ -27,14 +27,6 @@ class RoleDistributor(commands.Cog):
         role_msg_id_file = open(os.path.join(bot_dir, "src/secrets/role_msg_id.txt"))
         self.role_msg_id = int(role_msg_id_file.read())
 
-    """
-    Print a message indicating it is ready
-    Primarily for debugging purposes
-    """
-
-    @commands.Cog.listener()
-    async def on_ready(self):
-        print("Bot is ready!")
 
     """
     Assign appropriate roles upon adding reactions

--- a/src/cogs/RoleDistributor.py
+++ b/src/cogs/RoleDistributor.py
@@ -27,13 +27,14 @@ class RoleDistributor(commands.Cog):
         self.role_mapping_file = os.path.join(bot_dir, "src/secrets/role_mappings.json")
 
         if not os.path.exists(self.role_mapping_file):
-            with open(self.role_mapping_file, "w") as f:
-                json.dump({}, f)
+            self._write_json({}, self.role_mapping_file)
 
         try:
             with open(self.role_mapping_file, "r") as f:
                 self.role_mapping = json.loads(f.read())
         except JSONDecodeError:
+            # Self-repair the file, but this means the mapping will be lost
+            self._write_json({}, self.role_mapping_file)
             self.role_mapping = {}
 
         self.role_collector = None

--- a/src/cogs/RoleDistributor.py
+++ b/src/cogs/RoleDistributor.py
@@ -2,8 +2,11 @@
 Use reactions to add and remove roles.
 Please ensure `secrets/role_msg_id.txt` contains the selected message ID 
 """
+from json.decoder import JSONDecodeError
+import typing
 import discord
-import os.path
+import json
+import os
 from discord.ext import commands
 
 
@@ -15,81 +18,251 @@ class RoleDistributor(commands.Cog):
     def __init__(self, client):
         self.client = client
 
-        # Mapping for emoji to role
-        self.emote_to_role = {"🚗": "certified-2nd-year", "🚙": "certified-3rd-year", "🏎️": "certified-4th-year"}
-
         # Parent directory of the bot repo; constructed as parentDir(srcDir(fileDir(file)))
         bot_dir = os.path.dirname(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         )
 
         # Role message ID to be receiving reacts
-        role_msg_id_file = open(os.path.join(bot_dir, "src/secrets/role_msg_id.txt"))
-        self.role_msg_id = int(role_msg_id_file.read())
+        self.role_mapping_file = os.path.join(bot_dir, "src/secrets/role_mappings.json")
 
+        if not os.path.exists(self.role_mapping_file):
+            with open(self.role_mapping_file, "w") as f:
+                json.dump({}, f)
 
-    """
-    Assign appropriate roles upon adding reactions
-    :param payload: object to access member and guild
-    """
+        try:
+            with open(self.role_mapping_file, "r") as f:
+                self.role_mapping = json.loads(f.read())
+        except JSONDecodeError:
+            self.role_mapping = {}
+
+        self.role_collector = None
+
+    @commands.command()
+    @commands.is_owner()
+    async def initialize_role_mapping(
+        self, ctx, message: discord.Message, *, options: str = ""
+    ):
+        """
+        Initializes an interactive role mapping session. For more information, type !help initialize_role_mapping
+
+        To map roles, initialize a session by typing:
+        !initialize_role_mapping <message_id> <options=[unique,]>
+
+        To add emotes and roles, use the following:
+        !add_role_mapping <emote> <role>
+
+        When you're done, type:
+        !finalize_role_mapping
+
+        Note that you can have as many messages mapped as you'd like.
+        """
+        if self.role_collector is not None:
+            return await ctx.send(
+                "You're already in a mapping session. Finalize it with `!finalize_role_mapping`"
+            )
+
+        if ctx.guild.id != message.guild.id:
+            return await ctx.send("This message isn't in this guild.")
+
+        if str(message.id) in self.role_mapping:
+            await ctx.send(
+                "The current message already has a mapping. Do you want to overwrite it? (y/n)"
+            )
+            reply = await ctx.bot.wait_for(
+                "message",
+                check=lambda m: m.channel == ctx.channel and m.author == ctx.author,
+                timeout=30,
+            )
+            if not reply or reply.content.lower() != "y":
+                return await ctx.send("Mapping cancelled.")
+
+        self.role_collector = {
+            "message": message,
+            "mapping": {},
+            "unique": "unique" in options,
+        }
+
+        await ctx.send(
+            "Session initialized. Add roles by using `!add_role_mapping <emote> <role>`, and finish by using `!finalize_role_mapping`"
+        )
+
+    @commands.command()
+    @commands.is_owner()
+    async def add_role_mapping(
+        self, ctx, emote: typing.Union[discord.Emoji, str], role: discord.Role
+    ):
+        """
+        Adds an emote to role mapping to the current interactive session.
+        """
+        if self.role_collector is None:
+            return await ctx.send(
+                "You're not in a mapping session. Start one with `!initialize_role_mapping`"
+            )
+
+        # We're going to be lazy and not check whether the string is a valid emoji
+        if isinstance(emote, str):
+            await ctx.send(
+                f"Note that `{emote}` should be a valid unicode emote. If it isn't, start over."
+            )
+            emote_str = emote
+        else:
+            emote_str = str(emote.id)
+
+        # Verify that we didn't already map the role
+        if str(role.id) in self.role_collector["mapping"].values():
+            return await ctx.send("This role is already mapped to an emote. Try again.")
+
+        # Verify that the role isn't mapped to another message already
+        for message, mapping in self.role_mapping.items():
+            mapping = mapping["mapping"]
+            if message == str(self.role_collector["message"].id):
+                continue
+            if str(role.id) in mapping.values():
+                return await ctx.send(
+                    f"This role is already mapped to an emote in another message. Try again. (message_id: `{message}`)"
+                )
+
+        self.role_collector["mapping"][emote_str] = str(role.id)
+        await ctx.send(
+            f"Successfully added `{emote}` for {role.mention}",
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
+
+    @commands.command()
+    @commands.is_owner()
+    async def finalize_role_mapping(self, ctx):
+        """
+        Finalizes the role mapping.
+        """
+        if self.role_collector is None:
+            return await ctx.send(
+                "You're not in a mapping session. Start one with `!initialize_role_mapping`"
+            )
+
+        if not self.role_collector["mapping"]:
+            await ctx.send("No mappings were added. Cancelling.")
+        else:
+            self.role_mapping[str(self.role_collector["message"].id)] = {
+                "mapping": self.role_collector["mapping"],
+                "unique": self.role_collector["unique"],
+            }
+            self._write_json(self.role_mapping, self.role_mapping_file)
+            message = self.role_collector["message"]
+            await message.clear_reactions()
+            for eid in self.role_collector["mapping"].keys():
+                try:
+                    emoji = discord.utils.get(self.client.emojis, id=int(eid))
+                except ValueError:
+                    emoji = eid
+                await message.add_reaction(emoji)
+            await ctx.send("Done!")
+
+        self.role_collector = None
+
+    @commands.command()
+    @commands.is_owner()
+    async def list_role_mappings(self, ctx):
+        """
+        Lists the role mapping to your internal console.
+        """
+        print(self.role_mapping)
+        await ctx.send("Check your console output for the log.")
+
+    @commands.command()
+    @commands.is_owner()
+    async def delete_role_mapping(self, ctx, message: discord.Message):
+        """
+        Deletes a role mapping.
+        """
+        if str(message.id) not in self.role_mapping:
+            return await ctx.send("That message doesn't have a registered listener.")
+
+        del self.role_mapping[str(message.id)]
+        self._write_json(self.role_mapping, self.role_mapping_file)
+        await message.clear_reactions()
+        await ctx.send("Done!")
+
+    @staticmethod
+    def _write_json(payload, file):
+        with open(file, "w") as f:
+            json.dump(payload, f)
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
-        message_id = payload.message_id
-        channel = self.client.get_channel(payload.channel_id)
-        message = await channel.fetch_message(payload.message_id)
-        reaction = discord.utils.get(message.reactions, emoji=payload.emoji.name)
-        # Verify if selected message is the role message
-        if message_id == self.role_msg_id:
+        """
+        Assign appropriate roles upon adding reactions
+        :param payload: object to access member and guild
+        """
+        if payload.user_id == self.client.user.id:
+            return
+        # Convert all the IDs to strings since our loaded JSON keys will be strings
+        message_id_str = str(payload.message_id)
+        emoji_id_str = (
+            str(payload.emoji)
+            if payload.emoji.is_unicode_emoji()
+            else str(payload.emoji.id)
+        )
+
+        if message_id_str in self.role_mapping:
+            mapping = self.role_mapping[message_id_str]["mapping"]
+            unique = self.role_mapping[message_id_str]["unique"]
             guild = self.client.get_guild(payload.guild_id)
-            # Map role to corresponding reaction
-            if payload.emoji.name in self.emote_to_role:
-                name = self.emote_to_role[payload.emoji.name]
-                role = discord.utils.get(guild.roles, name=name)
-            else:
-                # Remove reactions not corresponding to roles
-                print("Please select either a red_car, blue_car, or race_car.")
-                await reaction.remove(payload.member)
-                return
+            member = guild.get_member(payload.user_id)
+            message = await self.client.get_channel(payload.channel_id).fetch_message(
+                payload.message_id
+            )
 
-            # Assign role to member
-            member = payload.member
-            if member is not None:
-                # Remove previous role and reaction
-                for r in message.reactions:
-                    if str(r) != str(payload.emoji):
-                        await message.remove_reaction(r.emoji, payload.member)
-                await member.add_roles(role)
-                print("Role assigned!")
+            if emoji_id_str in mapping:
+                role = discord.utils.get(guild.roles, id=int(mapping[emoji_id_str]))
+                if member is not None and role is not None:
+                    if unique:
+                        all_roles = [
+                            discord.utils.get(guild.roles, id=int(r))
+                            for r in mapping.values()
+                        ]
+                        await member.remove_roles(
+                            *[r for r in all_roles if r in member.roles],
+                        )
+                        for r in message.reactions:
+                            if str(r) != str(payload.emoji):
+                                await message.remove_reaction(r.emoji, member)
+                    await member.add_roles(role)
+                    print("Role assigned!")
+                else:
+                    print("Member not found, or role was invalid.")
             else:
-                print("Member not found.")
-
-    """
-    Unassign roles upon removing reactions 
-    :param payload: object to access member and guild
-    """
+                await message.remove_reaction(payload.emoji, member)
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):
-        message_id = payload.message_id
-        # Verify if selected message is the role message
-        if message_id == self.role_msg_id:
-            guild = self.client.get_guild(payload.guild_id)
-            # Map role to corresponding reaction
-            if payload.emoji.name in self.emote_to_role:
-                name = self.emote_to_role[payload.emoji.name]
-                role = discord.utils.get(guild.roles, name=name)
-            else:
-                print("Please select either a red_car, blue_car, or race_car.")
-                return
+        """
+        Unassign roles upon removing reactions
+        :param payload: object to access member and guild
+        """
+        if payload.user_id == self.client.user.id:
+            return
 
-            # Unassign role from member
+        message_id_str = str(payload.message_id)
+        emoji_id_str = (
+            str(payload.emoji)
+            if payload.emoji.is_unicode_emoji()
+            else str(payload.emoji.id)
+        )
+
+        if message_id_str in self.role_mapping:
+            mapping = self.role_mapping[message_id_str]["mapping"]
+            guild = self.client.get_guild(payload.guild_id)
             member = guild.get_member(payload.user_id)
-            if member is not None:
-                await member.remove_roles(role)
-                print("Role removed!")
-            else:
-                print("Member not found.")
+
+            if emoji_id_str in mapping:
+                role = discord.utils.get(guild.roles, id=int(mapping[emoji_id_str]))
+
+                if member is not None and role is not None:
+                    await member.remove_roles(role)
+                    print("Role removed!")
+                else:
+                    print("Member not found.")
 
 
 def setup(client):


### PR DESCRIPTION
A couple main things:
- Moved the `on_ready` listener to the main file
- Added an interactive setup tool for the role reacts; this allows it to support multiple messages being set up for role distribution
- Updated README

Note that the setup tool relies on state within the class (namely, `role_collector`). This isn't the best way of approaching this tool, but in this case we can take advantage of d.py's typing converters to ensure the correct arguments are being passed in (eg. `discord.Message`, `discord.Role`, etc).  In addition, the logic is relatively simple but there are just a bunch of checks that give the interactive tool more redundancies. 