### PR TITLE
Add boundary check to regex.

### DIFF
--- a/src/cogs/PrequisiteChecker.py
+++ b/src/cogs/PrequisiteChecker.py
@@ -14,7 +14,7 @@ class CourseConverter(commands.Converter):
     async def convert(self, ctx, argument):
         if len(argument) > 8:
             raise commands.errors.BadArgument
-        match = re.search(r"([A-Za-z]{4})([0-9]{3}[A-Za-z]{0,1})", argument)
+        match = re.search(r"\b([A-Za-z]{4})([0-9]{3}[A-Za-z]{0,1})\b", argument)
         if match:
             dept, course = match.groups()
             if not dept or not course:


### PR DESCRIPTION
Small change, but something I forgot.

Right now, the regex succeeds on `elec2011`, `elecc201`, and `elec201aa`, which obviously aren't well-formed. This eliminates those edge-cases.

Regex is hard.