### PR TITLE
Use a kwarg to capture the rest of the command.

### DIFF
--- a/src/cogs/Repl.py
+++ b/src/cogs/Repl.py
@@ -18,7 +18,7 @@ class Code(commands.Converter):
     """
 
     async def convert(self, ctx, argument):
-        match = re.search(r"\`\`\`(?:[\S]*)\n([\s\S]*)\`\`\`", ctx.message.content)
+        match = re.search(r"\`\`\`(?:[\S]*)\n([\s\S]*)\`\`\`", argument)
         return match.group(1) if match else None
 
 
@@ -38,7 +38,7 @@ class Repl(commands.Cog):
     @commands.command()
     @commands.max_concurrency(2)
     @commands.guild_only()
-    async def repl(self, ctx, language: str, code: Code):
+    async def repl(self, ctx, language: str, *, code: Code):
         """Run code. Supports java, python, and javascript (node) as the language parameter.
         Code parameter should be in a code block."""
         if self.repl_endpoint:


### PR DESCRIPTION
Just slightly better handling of the argument; this change fixes single-line inputs that have quotations (d.py parses them which we don't want).