### PR TITLE
Refactor of FaqManager.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ python_env
 secrets
 __pycache__
 .DS_Store
+assets/extra_commands.json

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ Once the repl service is initialized, this cog can be set up with `!set_repl htt
 #### FAQ
 
 Commands can be found within the `FaqManager.py` file.
-A Frequently Asked Questions (FAQ) document can be brought up with the various commands. In addition, it will link to a document which will be hosted on Google Drive and open to suggestions for all ECE members to contribute.
+A Frequently Asked Questions (FAQ) document can be brought up with the various commands. In addition, it will link to a document which will be hosted on Google Drive and open to suggestions for all ECE members to contribute. The default commands are:
 - `!programs`: Brings up program links for ECE, including MASc and MEng.
 - `!interviews`: Brings up a self-written ECE interview prep guide, which is a WIP.
 - `!leetcode`: Brings up a self-written LeetCode introductory prep guide, which can be found [here](https://docs.google.com/document/d/16BeYJzj_az-8Zv562RgZ0M_mxvCo6W6Thhc0D1oaNwE/edit?usp=sharing).
 - `!blind75`: Brings up the Blind 75 LeetCode list, which can be found [here](https://docs.google.com/spreadsheets/d/1O6lu-27mkdEfQAFfMB43vcqZRF57ygtJO2tCDw2ZQaY/edit?usp=sharing).
 - `!repo`: Brings up the Github repository for the ECESS Discord Bot.
+
+New custom commands can be added with `!add <command> <content>`, which can be brought up by other members with `!<command>`. To remove that custom command, simply invoke `!remove <command>`.
 
 ## Troubleshooting
 ### SSL Certificate Expiration on Windows

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ECESS Discord Bot
 
-A Discord bot to be deployed on the [Electrical and Computer Engineering Student Society](http://ubcecess.com/) (ECESS) server. 
+A Discord bot to be deployed on the [Electrical and Computer Engineering Student Society](http://ubcecess.com/) (ECESS) server.
 
 The motivation to build a custom bot against using pre-built solutions (such as MEE6) stemmed from the lack of flexibility for additional features beyond role distribution.
 
 ## Progress
 
 The following features are currently supported:
+
 - Assigning roles from reaction messages
 - ECE FAQ commands
 - Prerequisite checker commands
@@ -18,16 +19,18 @@ The following features are currently supported:
 ## Installation
 
 The bot is currently not live. The instructions are meant for testing on your local machine.
+
 1. Clone the repository.
 2. Ensure [Python](https://www.python.org/) is installed. Please also install the [discord.py](https://discordpy.readthedocs.io/en/latest/intro.html#installing) library and check `requirements.txt` file for additional library details. If possible, use a virtual environment when installing libraries.
 3. Within the [Discord Developer Portal](https://discord.com/developers/applications), create a new application. Within the Settings panel, navigate to Bot to create a bot.
 4. Create a `secrets` directory, which will hold your private files. Within the `src/secrets` folder, create a `token.txt` file. Copy the token from the Build-A-Bot configuration into the `token.txt` file. Remember not to share your token with anyone.
 5. Within the `src/secrets` folder, create a `role_msg_id.txt` file. Enable [Developer Mode](https://discordia.me/en/developer-mode) on your server. Find the message you will be using to assign roles. Right-click and copy the message ID. Copy and paste the message ID into the `role_msg_id.txt` file.
-6. Invite the bot into your server through the Developer Portal. This is found in the OAuth2 section of the Settings. Remember to put the bot on a higher privilege than the roles you are assigning.  
+6. Invite the bot into your server through the Developer Portal. This is found in the OAuth2 section of the Settings. Remember to put the bot on a higher privilege than the roles you are assigning.
 7. Test the bot by navigating to `src` and running `python3 EcessClient.py`. The bot will be online when the console displays `Bot is ready!`.
 8. (Optional) To format your Python files, run `chmod +x fix_formatting.sh` to enable execute permissions. Proceed to run `./fix_formatting.sh`, which will run the [Black](https://github.com/psf/black) code formatter.
 
 ## Features
+
 ### Role Distribution
 
 Roles can be distributed arbitrarily and set up with the interactive mapper within the `RoleDistributor.py` file.
@@ -48,8 +51,8 @@ Once you're done, finalize the mapping with `!finalize_role_mapping`. This will 
 
 - Mapping can only be done by the bot owner at this time (TODO)
 
-
 ### Commands
+
 #### Prerequisite Checking
 
 Commands can be found within the `PrerequisiteChecker.py` file.
@@ -75,15 +78,26 @@ Once the repl service is initialized, this cog can be set up with `!set_repl htt
 
 Commands can be found within the `FaqManager.py` file.
 A Frequently Asked Questions (FAQ) document can be brought up with the various commands. In addition, it will link to a document which will be hosted on Google Drive and open to suggestions for all ECE members to contribute. The default commands are:
+
 - `!programs`: Brings up program links for ECE, including MASc and MEng.
 - `!interviews`: Brings up a self-written ECE interview prep guide, which is a WIP.
 - `!leetcode`: Brings up a self-written LeetCode introductory prep guide, which can be found [here](https://docs.google.com/document/d/16BeYJzj_az-8Zv562RgZ0M_mxvCo6W6Thhc0D1oaNwE/edit?usp=sharing).
 - `!blind75`: Brings up the Blind 75 LeetCode list, which can be found [here](https://docs.google.com/spreadsheets/d/1O6lu-27mkdEfQAFfMB43vcqZRF57ygtJO2tCDw2ZQaY/edit?usp=sharing).
 - `!repo`: Brings up the Github repository for the ECESS Discord Bot.
 
+More default commands can be added by adding them in `assets/default_commands.json`. The structure follows:
+
+```json
+"command_name": {
+    "description": "description in the help text",
+    "content": "content of the command"
+}
+```
+
 New custom commands can be added with `!add <command> <content>`, which can be brought up by other members with `!<command>`. To remove that custom command, simply invoke `!remove <command>`.
 
 ## Troubleshooting
+
 ### SSL Certificate Expiration on Windows
 
 The solution can be found on a Github issue comment [here](https://github.com/Rapptz/discord.py/issues/4159#issuecomment-640107584). Downloading and installing the certificate can be done from [here](https://crt.sh/?id=2835394). The download link can be explicitly found [here](https://beans-took-my-kids.reeee.ee/38qB2n.png).

--- a/assets/default_commands.json
+++ b/assets/default_commands.json
@@ -1,0 +1,18 @@
+{
+  "programs": {
+    "description": "Bring up ECE program details",
+    "content": "CPEN: https://www.ece.ubc.ca/academic-programs/undergraduate/programs/computer-engineering-program \nELEC: https://www.ece.ubc.ca/academic-programs/undergraduate/programs/electrical-engineering-program \nMASc/MEng: http://www.ece.ubc.ca/admissions/graduate/apply"
+  },
+  "leetcode": {
+    "description": "Bring up the LeetCode Intro Prep Guide",
+    "content": "LC Intro Guide: <https://docs.google.com/document/d/16BeYJzj_az-8Zv562RgZ0M_mxvCo6W6Thhc0D1oaNwE/edit?usp=sharing> \nTo bring up the Blind75 list, please use `!blind75`"
+  },
+  "blind75": {
+    "description": "Bring up the Blind75 LeetCode list",
+    "content": "Blind75 LC List: <https://docs.google.com/spreadsheets/d/1O6lu-27mkdEfQAFfMB43vcqZRF57ygtJO2tCDw2ZQaY/edit?usp=sharing>"
+  },
+  "repo": {
+    "description": "Bring up the bot's Github repository",
+    "content": "ECESS Discord Bot's Github Repo: <https://github.com/kelvinkoon/ecess-discord-bot>"
+  }
+}

--- a/src/EcessClient.py
+++ b/src/EcessClient.py
@@ -16,6 +16,7 @@ def main():
 
     # Initialize the client
     client = commands.Bot(intents=intents, command_prefix="!")
+    client.bot_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     @client.event
     async def on_ready():


### PR DESCRIPTION
Small little refactor, but it should give us more flexibility (like for e-week stuff, for example).

The hardcoded commands have been moved out to an initializer that adds the commands at runtime. A caveat to this is they won't show up under `!help FaqManager` anymore, but they'll show up in the general `!help` menu since it's unscoped.

This also adds two commands, `!add <command> <content>` and `!remove <command>` which adds that flexibility I mentioned.